### PR TITLE
Fix bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DoneCommand.java
@@ -59,11 +59,14 @@ public class DoneCommand extends Command {
         Visit newLastVisit = personToDone.getVisit().get();
         Optional<LastVisit> newLastVisited = Optional.of(new LastVisit(newLastVisitedDate));
 
-        Occurrence currentOccurrence = personToDone.getOccurrence().get();
+        Occurrence currentOccurrence = personToDone.getOccurrence().orElse(Occurrence.EMPTY_OCCURENCE);
+        Frequency currentFrequency = personToDone.getFrequency().orElse(Frequency.EMPTY);
+
         Optional<Occurrence> newOccurrence;
         Optional<Visit> newVisit;
-        Frequency currentFrequency = personToDone.getFrequency().get();
-        if (currentOccurrence.value == 1) {
+
+
+        if (currentOccurrence.value == 1 || currentFrequency.isEmpty()) {
             newOccurrence = Optional.of(new Occurrence(1));
             newVisit = Optional.ofNullable(new Visit(""));
         } else {

--- a/src/main/java/seedu/address/model/person/Occurrence.java
+++ b/src/main/java/seedu/address/model/person/Occurrence.java
@@ -8,6 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Occurrence {
     public static final String MESSAGE_CONSTRAINTS =
             "Occurrence should be positive number.";
+    public static final Occurrence EMPTY_OCCURENCE = new Occurrence(1);
 
     public final int value;
 


### PR DESCRIPTION
Solves #89 

The bug happens when `add` a new person with `visit` field not empty then try to mark the person's visit as `done`. 

It is because a `visit` added upon adding the person does not have `frequency` or `occurrence` so they will throw exceptions when trying to update in `done`.

A quick is to check their values and treat the visit as an ad-hoc one if `frequency` or `occurrence` are not present / set.