### PR TITLE
Update command result message for sort and display for delete

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_NO_EXISTING_VISIT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VISIT;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Optional;
@@ -84,7 +85,7 @@ public class DeleteCommand extends Command {
                 personToDelete.getAddress(), personToDelete.getLastVisit(), EMPTY_VISIT, Optional.of(Frequency.EMPTY),
                         Optional.of(new Occurrence(1)), personToDelete.getHealthConditions());
         model.setPerson(personToDelete, editedPerson);
-
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_DELETE_VISIT_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -6,8 +6,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_VISIT;
 
 import java.util.Comparator;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.SortComparator;
 import seedu.address.model.Model;
+import seedu.address.model.person.LastVisit;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Visit;
 
 /*
  * Sorts all persons in the address book to the user.
@@ -22,7 +27,7 @@ public class SortCommand extends Command {
             + "Parameters: [" + PREFIX_VISIT + "] or [" + PREFIX_LAST_VISIT + "]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_VISIT + " or " + COMMAND_WORD + " " + PREFIX_LAST_VISIT;
 
-    public static final String MESSAGE_SUCCESS = "Sorted listed persons successfully";
+    public static final String MESSAGE_SUCCESS = "Sorted listed persons successfully by %1$s";
 
     private final Comparator<Person> comparator;
     private final boolean isAscending;
@@ -37,10 +42,20 @@ public class SortCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.sortFilteredPersonList(comparator, isAscending);
-        return new CommandResult(MESSAGE_SUCCESS);
+
+        if (comparator.equals(SortComparator.SORT_BY_NEXT_VISIT)) {
+            return new CommandResult(String.format(MESSAGE_SUCCESS, Visit.class.getSimpleName()));
+
+        } else if (comparator.equals(SortComparator.SORT_BY_LAST_VISIT)) {
+            return new CommandResult(String.format(MESSAGE_SUCCESS, LastVisit.class.getSimpleName()));
+
+        } else {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        }
+
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -86,7 +87,6 @@ public class DeleteCommandTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
-
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
@@ -102,9 +102,7 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
-
-        NameContainsKeywordsPredicate predicate = preparePredicate(editedPerson.getName().toString());
-        expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,20 +1,28 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.SortComparator;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.LastVisit;
 import seedu.address.model.person.PersonAttributesContainsKeywordsPredicate;
+import seedu.address.model.person.Visit;
 
 public class SortCommandTest {
     private static final PersonAttributesContainsKeywordsPredicate PREDICATE_STUB = preparePredicate("meier");
+    private static final String SUCCESS_MESSAGE_VISIT =
+            String.format(SortCommand.MESSAGE_SUCCESS, Visit.class.getSimpleName());
+    private static final String SUCCESS_MESSAGE_LAST_VISIT =
+            String.format(SortCommand.MESSAGE_SUCCESS, LastVisit.class.getSimpleName());
     private Model model;
     private Model expectedModel;
 
@@ -26,31 +34,44 @@ public class SortCommandTest {
 
     @Test
     public void execute_sortUnfilteredListByNextVisit_showEverythingSorted() {
+        // sort by visit
         SortCommand sortByNextVisitCommand = new SortCommand(SortComparator.SORT_BY_NEXT_VISIT, true);
         expectedModel.sortFilteredPersonList(SortComparator.SORT_BY_NEXT_VISIT, true);
-        assertCommandSuccess(sortByNextVisitCommand, model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(sortByNextVisitCommand, model, SUCCESS_MESSAGE_VISIT, expectedModel);
 
+        // sort by last visit
         SortCommand sortByLastVisitCommand = new SortCommand(SortComparator.SORT_BY_LAST_VISIT, false);
         expectedModel.sortFilteredPersonList(SortComparator.SORT_BY_LAST_VISIT, false);
-        assertCommandSuccess(sortByLastVisitCommand, model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(sortByLastVisitCommand, model, SUCCESS_MESSAGE_LAST_VISIT, expectedModel);
     }
 
     @Test
     public void execute_sortFilteredListByNextVisit_showFilteredSorted() {
         model.updateFilteredPersonList(PREDICATE_STUB);
         expectedModel.updateFilteredPersonList(PREDICATE_STUB);
+
         SortCommand sortCommand = new SortCommand(SortComparator.SORT_BY_LAST_VISIT, false);
         expectedModel.sortFilteredPersonList(SortComparator.SORT_BY_LAST_VISIT, false);
-        assertCommandSuccess(sortCommand, model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+
+        assertCommandSuccess(sortCommand, model, SUCCESS_MESSAGE_LAST_VISIT, expectedModel);
     }
 
     @Test
     public void execute_sortFilteredListByLastVisit_showFilteredSorted() {
         model.updateFilteredPersonList(PREDICATE_STUB);
         expectedModel.updateFilteredPersonList(PREDICATE_STUB);
+
         SortCommand sortCommand = new SortCommand(SortComparator.SORT_BY_NEXT_VISIT, true);
         expectedModel.sortFilteredPersonList(SortComparator.SORT_BY_NEXT_VISIT, true);
-        assertCommandSuccess(sortCommand, model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+
+        assertCommandSuccess(sortCommand, model, SUCCESS_MESSAGE_VISIT, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidComparator_throwCommandException() {
+        SortCommand sortCommand = new SortCommand(SortComparator.SORT_BY_NAME, true);
+        String errorMessage = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
+        assertCommandFailure(sortCommand, model, errorMessage);
     }
 
     /**


### PR DESCRIPTION
SortCommand does not show the sort parameter after execution.
DeleteCommand does not go back to the original list after deleting a visit.

Let's
* Update SortCommand command result to include the parameter.
* Return to the original list after deleting a visit.

Closes #112 