### PR TITLE
Rework parsing criteria for list incoming command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,30 +1,29 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INCOMING_MONTH;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INCOMING_WEEK;
 
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class ListCommandParser implements Parser<ListCommand> {
-    private static final String ARGS_LIST_ALL = "";
-    private static final String ARGS_LIST_WEEK_TRIMMED = "w/";
-    private static final String ARGS_LIST_MONTH_TRIMMED = "m/";
-
     /**
      * Parses the given {@code String} of arguments in the context of the ListCommand
      * @throws ParseException if the user input does not conform the expected format
      */
     public ListCommand parse(String args) throws ParseException {
-        String argsTrimmed = args.trim();
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_INCOMING_MONTH, PREFIX_INCOMING_WEEK);
 
-        if (argsTrimmed.equals(ARGS_LIST_ALL)) {
-            return new ListCommand();
-        } else if (argsTrimmed.equals(ARGS_LIST_MONTH_TRIMMED)) {
+        if (argMultimap.isAllPresent(PREFIX_INCOMING_MONTH, PREFIX_INCOMING_WEEK)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        } else if (argMultimap.getValue(PREFIX_INCOMING_MONTH).isPresent()) {
             return new ListCommand(true, true);
-        } else if (argsTrimmed.equals(ARGS_LIST_WEEK_TRIMMED)) {
+        } else if (argMultimap.getValue(PREFIX_INCOMING_WEEK).isPresent()) {
             return new ListCommand(true, false);
         } else {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+            return new ListCommand();
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -19,6 +19,7 @@ public class ListCommandParserTest {
 
         // no prefix means list all
         assertParseSuccess(parser, "", listCommandAll);
+        assertParseSuccess(parser, "abc", listCommandAll);
     }
 
     @Test
@@ -28,6 +29,11 @@ public class ListCommandParserTest {
 
         assertParseSuccess(parser, String.format(" %s", PREFIX_INCOMING_MONTH), listCommandNextMonth);
         assertParseSuccess(parser, String.format(" %s", PREFIX_INCOMING_WEEK), listCommandNextWeek);
+
+        // with extra strings that follow -> accept
+        assertParseSuccess(parser, String.format(" %s 123", PREFIX_INCOMING_MONTH), listCommandNextMonth);
+        assertParseSuccess(parser, String.format("abc %s", PREFIX_INCOMING_WEEK), listCommandNextWeek);
+
     }
 
     @Test
@@ -37,15 +43,5 @@ public class ListCommandParserTest {
         // both flag -> invalid
         assertParseFailure(parser,
                 String.format(" %s %s", PREFIX_INCOMING_MONTH, PREFIX_INCOMING_WEEK), expectedMessage);
-    }
-
-    @Test
-    public void parser_extraArgs_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE);
-
-        String argsTrailingExtra = String.format(" %s123", PREFIX_INCOMING_WEEK);
-        String argsPrecedingExtra = String.format("abc %s", PREFIX_INCOMING_WEEK);
-        assertParseFailure(parser, argsTrailingExtra, expectedMessage);
-        assertParseFailure(parser, argsPrecedingExtra, expectedMessage);
     }
 }


### PR DESCRIPTION
Addresses #126 

Allow for redundant arguments in `list` command, in the same as `sort` and other commands do.