### PR TITLE
Yiyang implement warning messages

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,4 +11,8 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d elderly listed!";
     public static final String MESSAGE_NO_EXISTING_VISIT = "No Next visit for the elderly: %1$s";
 
+    // warnings
+    public static final String MESSAGE_INVALID_LAST_VISIT_DATE = "Last visit date should be in the past.";
+    public static final String MESSAGE_INVALID_VISIT_DATE = "Visit date should be in the future.";
+
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -82,7 +82,7 @@ public class AddCommand extends Command {
         boolean isInvalidVisit = toAdd.hasVisit() && toAdd.getVisit().get().isOverdue();
         boolean isInvalidLastVisit = toAdd.hasLastVisit() && toAdd.getLastVisit().get().isFuture();
 
-        if (isInvalidLastVisit && isInvalidLastVisit) {
+        if (isInvalidVisit && isInvalidLastVisit) {
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandWarning.BOTH_VISIT_FIELDS_WARNING);
         } else if (isInvalidLastVisit) {
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandWarning.FUTURE_LAST_VISIT_WARNING);

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -77,9 +77,20 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_INVALID_OPTIONAL_FREQUENCY_FLAG);
         }
 
-
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+
+        boolean isInvalidVisit = toAdd.hasVisit() && toAdd.getVisit().get().isOverdue();
+        boolean isInvalidLastVisit = toAdd.hasLastVisit() && toAdd.getLastVisit().get().isFuture();
+
+        if (isInvalidLastVisit && isInvalidLastVisit) {
+            return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandWarning.BOTH_VISIT_FIELDS_WARNING);
+        } else if (isInvalidLastVisit) {
+            return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandWarning.FUTURE_LAST_VISIT_WARNING);
+        } else if (isInvalidVisit) {
+            return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandWarning.PAST_NEXT_VISIT_WARNING);
+        } else {
+            return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -3,11 +3,14 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents the result of a command execution.
  */
 public class CommandResult {
+
+    private static String WARNING_FORMAT = "[WARNING] %1$s\n";
 
     private final String feedbackToUser;
 
@@ -23,16 +26,28 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    private final Optional<CommandWarning> warning;
+
+    /**
+     * Constructs a {@code CommandResult} with the specified fields.
+     * Overloaded method where by default the result is normal
+     */
+    public CommandResult(String feedbackToUser, boolean showSummary, boolean showHelp,
+                         boolean showDownload, boolean exit) {
+        this(feedbackToUser, showSummary, showHelp, showDownload, exit, null);
+    }
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
     public CommandResult(String feedbackToUser, boolean showSummary, boolean showHelp,
-                         boolean showDownload, boolean exit) {
+                         boolean showDownload, boolean exit, CommandWarning warning) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showSummary = showSummary;
         this.showHelp = showHelp;
         this.showDownload = showDownload;
         this.exit = exit;
+        this.warning = (warning != null) ? Optional.of(warning) : Optional.empty();
     }
 
     /**
@@ -43,8 +58,21 @@ public class CommandResult {
         this(feedbackToUser, false, false, false, false);
     }
 
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, and warning
+     * and other fields set to their default value.
+     */
+    public CommandResult(String feedbackToUser, CommandWarning warning) {
+        this(feedbackToUser, false, false, false, false, warning);
+    }
+
     public String getFeedbackToUser() {
-        return feedbackToUser;
+        if (hasWarning()) {
+            return String.format(WARNING_FORMAT, getWarning()) + feedbackToUser;
+        }
+        else {
+            return feedbackToUser;
+        }
     }
 
     public boolean isShowSummary() {
@@ -63,6 +91,18 @@ public class CommandResult {
         return exit;
     }
 
+    public boolean hasWarning() {
+        return !warning.isEmpty();
+    }
+
+    public String getWarning() {
+        if (hasWarning()) {
+            return warning.get().getValue();
+        } else {
+            return "";
+        }
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -79,12 +119,13 @@ public class CommandResult {
                 && showSummary == otherCommandResult.showSummary
                 && showHelp == otherCommandResult.showHelp
                 && showDownload == otherCommandResult.showDownload
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && warning == otherCommandResult.warning;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showSummary, showHelp, showDownload, exit);
+        return Objects.hash(feedbackToUser, showSummary, showHelp, showDownload, exit, warning);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -10,7 +10,7 @@ import java.util.Optional;
  */
 public class CommandResult {
 
-    private static String WARNING_FORMAT = "[WARNING] %1$s\n";
+    public static String WARNING_FORMAT = "[WARNING] %1$s\n";
 
     private final String feedbackToUser;
 

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -10,7 +10,7 @@ import java.util.Optional;
  */
 public class CommandResult {
 
-    public static String WARNING_FORMAT = "[WARNING] %1$s\n";
+    public static final String WARNING_FORMAT = "[WARNING] %1$s\n";
 
     private final String feedbackToUser;
 
@@ -69,8 +69,7 @@ public class CommandResult {
     public String getFeedbackToUser() {
         if (hasWarning()) {
             return String.format(WARNING_FORMAT, getWarning()) + feedbackToUser;
-        }
-        else {
+        } else {
             return feedbackToUser;
         }
     }

--- a/src/main/java/seedu/address/logic/commands/CommandWarning.java
+++ b/src/main/java/seedu/address/logic/commands/CommandWarning.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_LAST_VISIT_DATE;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_VISIT_DATE;
+
+public class CommandWarning {
+
+    public static final CommandWarning FUTURE_LAST_VISIT_WARNING = new CommandWarning(MESSAGE_INVALID_LAST_VISIT_DATE);
+    public static final CommandWarning PAST_NEXT_VISIT_WARNING = new CommandWarning(MESSAGE_INVALID_VISIT_DATE);
+    public static final CommandWarning BOTH_VISIT_FIELDS_WARNING = new CommandWarning(
+            MESSAGE_INVALID_LAST_VISIT_DATE + " " + MESSAGE_INVALID_VISIT_DATE);
+
+    private final String value;
+
+    public CommandWarning(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CommandWarning that = (CommandWarning) o;
+
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CommandWarning.java
+++ b/src/main/java/seedu/address/logic/commands/CommandWarning.java
@@ -21,6 +21,11 @@ public class CommandWarning {
     }
 
     @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -94,7 +94,7 @@ public class EditCommand extends Command {
         boolean isInvalidVisit = editedPerson.hasVisit() && editedPerson.getVisit().get().isOverdue();
         boolean isInvalidLastVisit = editedPerson.hasLastVisit() && editedPerson.getLastVisit().get().isFuture();
 
-        if (isInvalidLastVisit && isInvalidLastVisit) {
+        if (isInvalidVisit && isInvalidLastVisit) {
             return new CommandResult(
                     String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson), CommandWarning.BOTH_VISIT_FIELDS_WARNING);
         } else if (isInvalidLastVisit) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -89,7 +89,23 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+
+        // check for warnings
+        boolean isInvalidVisit = editedPerson.hasVisit() && editedPerson.getVisit().get().isOverdue();
+        boolean isInvalidLastVisit = editedPerson.hasLastVisit() && editedPerson.getLastVisit().get().isFuture();
+
+        if (isInvalidLastVisit && isInvalidLastVisit) {
+            return new CommandResult(
+                    String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson), CommandWarning.BOTH_VISIT_FIELDS_WARNING);
+        } else if (isInvalidLastVisit) {
+            return new CommandResult(
+                    String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson), CommandWarning.FUTURE_LAST_VISIT_WARNING);
+        } else if (isInvalidVisit) {
+            return new CommandResult(
+                    String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson), CommandWarning.PAST_NEXT_VISIT_WARNING);
+        } else {
+            return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/VisitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/VisitCommand.java
@@ -85,7 +85,11 @@ public class VisitCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(generateSuccessMessage(editedPerson));
+        if (visit.isPresent() && visit.get().isOverdue()) {
+            return new CommandResult(generateSuccessMessage(editedPerson), CommandWarning.PAST_NEXT_VISIT_WARNING);
+        } else {
+            return new CommandResult(generateSuccessMessage(editedPerson));
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -187,12 +187,6 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_DATE);
         }
 
-        /*
-        if (DateTimeUtil.isPast(parsedVisit)) {
-            throw new ParseException(MESSAGE_INVALID_VISIT_DATE);
-        }
-
-         */
 
         return Optional.ofNullable(new Visit(trimmedVisit));
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -33,8 +33,6 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_DATE = "Date is invalid.";
-    public static final String MESSAGE_INVALID_LAST_VISIT_DATE = "Last visit date should be in the past.";
-    public static final String MESSAGE_INVALID_VISIT_DATE = "Visit date should be in the future.";
     public static final String MESSAGE_INVALID_FREQUENCY = "Frequency can only be daily, weekly, "
             + "biweekly, monthly or quarterly.";
     public static final String MESSAGE_INVALID_OCCURRENCE =
@@ -165,10 +163,6 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_DATE);
         }
 
-        if (DateTimeUtil.isFuture(parsedLastVisit)) {
-            throw new ParseException(MESSAGE_INVALID_LAST_VISIT_DATE);
-        }
-
         return Optional.ofNullable(new LastVisit(trimmedLastVisit));
     }
 
@@ -193,9 +187,12 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_DATE);
         }
 
+        /*
         if (DateTimeUtil.isPast(parsedVisit)) {
             throw new ParseException(MESSAGE_INVALID_VISIT_DATE);
         }
+
+         */
 
         return Optional.ofNullable(new Visit(trimmedVisit));
     }
@@ -225,9 +222,6 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_DATE);
         }
 
-        if (DateTimeUtil.isPast(parsedVisit)) {
-            throw new ParseException(MESSAGE_INVALID_VISIT_DATE);
-        }
 
         return Optional.ofNullable(new Visit(trimmedVisit));
     }

--- a/src/main/java/seedu/address/model/person/LastVisit.java
+++ b/src/main/java/seedu/address/model/person/LastVisit.java
@@ -28,6 +28,13 @@ public class LastVisit {
     }
 
     /**
+     * Determines whether the visit is empty based on value
+     */
+    public boolean hasLastVisit() {
+        return !(this.value == null || this.value.isEmpty());
+    }
+
+    /**
      * Returns true if a given string is a valid last visit.
      */
     public static boolean isValidLastVisit(String test) {
@@ -42,6 +49,24 @@ public class LastVisit {
             return false;
         }
         return DateTimeUtil.isLastSevenDays(LocalDateTime.parse(value, DateTimeUtil.FORMATTER));
+    }
+
+    /**
+     * Returns true if the last visit date is in the future
+     */
+    public boolean isFuture() {
+        if (!hasLastVisit()) {
+            return false;
+        }
+
+        LocalDateTime visitTime;
+        try {
+            visitTime = LocalDateTime.parse(value, DateTimeUtil.FORMATTER);
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+
+        return DateTimeUtil.isFuture(visitTime);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -109,6 +109,13 @@ public class Person {
     }
 
     /**
+     * Returns true if the person has a scheduled last visit.
+     */
+    public boolean hasLastVisit() {
+        return (this.lastVisit.get().hasLastVisit());
+    }
+
+    /**
      * Returns if the person has an existing visit that is overdue.
      * Only the immediate visit will be examined, not the recurring ones that follow.
      */

--- a/src/main/java/seedu/address/model/person/Visit.java
+++ b/src/main/java/seedu/address/model/person/Visit.java
@@ -36,7 +36,6 @@ public class Visit {
 
     /**
      * Determines whether the visit is empty based on value
-     * @return whether the visit is empty
      */
     public boolean hasVisit() {
         return !(this.value == null || this.value.isEmpty());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -229,6 +229,7 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            resultDisplay.setColorBasedOnResultType(commandResult.hasWarning());
 
             if (commandResult.isShowSummary()) {
                 handleSummary();
@@ -252,6 +253,7 @@ public class MainWindow extends UiPart<Stage> {
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
+            resultDisplay.setColorBasedOnResultType(false);
             throw e;
         }
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -229,7 +229,7 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-            resultDisplay.setColorBasedOnResultType(commandResult.hasWarning());
+            resultDisplay.setColorBasedOnResultType(commandResult.hasWarning(), false);
 
             if (commandResult.isShowSummary()) {
                 handleSummary();
@@ -252,8 +252,8 @@ public class MainWindow extends UiPart<Stage> {
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);
-            resultDisplay.setFeedbackToUser(e.getMessage());
-            resultDisplay.setColorBasedOnResultType(false);
+            resultDisplay.setFeedbackToUser("[ERROR] " + e.getMessage());
+            resultDisplay.setColorBasedOnResultType(false, true);
             throw e;
         }
     }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -16,8 +16,8 @@ import seedu.address.model.person.Person;
  */
 public class PersonCard extends UiPart<Region> {
 
-    public static final String OVERDUE_CARD_STYLE_CLASS = "overdue-card";
-    public static final String OVERDUE_VISIT_STYLE_CLASS = "overdue-visit";
+    private static final String OVERDUE_CARD_STYLE_CLASS = "overdue-card";
+    private static final String OVERDUE_VISIT_STYLE_CLASS = "overdue-visit";
 
     private static final String FXML = "PersonListCard.fxml";
     private static final String DISPLAY_LAST_VISIT = "Last visit: ";

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -15,6 +15,7 @@ public class ResultDisplay extends UiPart<Region> {
     private static final String FXML = "ResultDisplay.fxml";
 
     private static final String WARNING_STYLE_CLASS = "warning";
+    private static final String ERROR_STYLE_CLASS = "error";
 
     @FXML
     private TextArea resultDisplay;
@@ -28,7 +29,7 @@ public class ResultDisplay extends UiPart<Region> {
         resultDisplay.setText(feedbackToUser);
     }
 
-    public void setColorBasedOnResultType(boolean isWarning) {
+    public void setColorBasedOnResultType(boolean isWarning, boolean isError) {
         ObservableList<String> styles = resultDisplay.getStyleClass();
 
         if (!isWarning) {
@@ -41,6 +42,15 @@ public class ResultDisplay extends UiPart<Region> {
             }
         }
 
+        if (!isError) {
+            if (styles.contains(ERROR_STYLE_CLASS)) {
+                styles.remove(ERROR_STYLE_CLASS);
+            }
+        } else {
+            if (!styles.contains(ERROR_STYLE_CLASS)) {
+                styles.add(ERROR_STYLE_CLASS);
+            }
+        }
     }
 
 }

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -2,6 +2,7 @@ package seedu.address.ui;
 
 import static java.util.Objects.requireNonNull;
 
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.Region;
@@ -13,6 +14,8 @@ public class ResultDisplay extends UiPart<Region> {
 
     private static final String FXML = "ResultDisplay.fxml";
 
+    private static final String WARNING_STYLE_CLASS = "warning";
+
     @FXML
     private TextArea resultDisplay;
 
@@ -23,6 +26,21 @@ public class ResultDisplay extends UiPart<Region> {
     public void setFeedbackToUser(String feedbackToUser) {
         requireNonNull(feedbackToUser);
         resultDisplay.setText(feedbackToUser);
+    }
+
+    public void setColorBasedOnResultType(boolean isWarning) {
+        ObservableList<String> styles = resultDisplay.getStyleClass();
+
+        if (!isWarning) {
+            if (styles.contains(WARNING_STYLE_CLASS)) {
+                styles.remove(WARNING_STYLE_CLASS);
+            }
+        } else {
+            if (!styles.contains(WARNING_STYLE_CLASS)) {
+                styles.add(WARNING_STYLE_CLASS);
+            }
+        }
+
     }
 
 }

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -3,6 +3,10 @@
     -fx-text-fill: #d06651 !important; /* The error class should always override the default text-fill style */
 }
 
+.warning {
+    -fx-text-fill: #E38633 !important;
+}
+
 .list-cell:empty {
     /* Empty cells will not have alternating colours */
     -fx-background: #ffffff;

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,7 +6,7 @@
     "language" : "English",
     "address" : "123, Jurong West Ave 6, #08-111",
     "lastVisit": "2021-07-07 12:00",
-    "visit" : "2021-10-10 12:00",
+    "visit" : "2022-10-10 12:00",
     "frequency": "",
     "occurrence": "1",
     "healthConditions" : [ "diabetes" ]

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -11,6 +11,7 @@ public class CommandResultTest {
     @Test
     public void equals() {
         CommandResult commandResult = new CommandResult("feedback");
+        CommandResult warnedResult = new CommandResult("feedback", CommandWarning.PAST_NEXT_VISIT_WARNING);
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
@@ -33,6 +34,10 @@ public class CommandResultTest {
 
         // different exit value -> returns false
         assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, true)));
+
+        // check for warnings
+        assertFalse(commandResult.equals(warnedResult));
+        assertFalse(warnedResult.equals(new CommandResult("feedback", CommandWarning.FUTURE_LAST_VISIT_WARNING)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandWarningTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandWarningTest.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+
+public class CommandWarningTest {
+    @Test
+    public void getValueTest() {
+        String expectedValue = Messages.MESSAGE_INVALID_VISIT_DATE;
+        assertEquals(CommandWarning.PAST_NEXT_VISIT_WARNING.getValue(), expectedValue);
+    }
+
+    @Test
+    public void equals() {
+        CommandWarning warning1 = new CommandWarning(Messages.MESSAGE_INVALID_LAST_VISIT_DATE);
+        assertTrue(warning1.equals(CommandWarning.FUTURE_LAST_VISIT_WARNING));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -37,7 +37,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Person editedPerson = new PersonBuilder().withVisit("2021-10-10 12:00")
+        Person editedPerson = new PersonBuilder().withVisit("2022-10-10 12:00")
                 .withLastVisit("2021-07-07 12:00").build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
@@ -98,6 +98,7 @@ public class EditCommandTest {
         expectedModel.setPerson(personInFilteredList, editedPerson);
         expectedModel.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
+        int i = 1;
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -229,10 +229,6 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, () -> ParserUtil.parseVisit(INVALID_DATETIME));
     }
 
-    @Test
-    public void parseVisit_invalidPastDateTime_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseVisit(INVALID_VISIT_DATETIME));
-    }
 
     @Test
     public void parseVisit_validValueWithoutWhitespace_returnsVisit() throws Exception {
@@ -262,10 +258,6 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, () -> ParserUtil.parseVisitForAdd(INVALID_DATETIME));
     }
 
-    @Test
-    public void parseVisitForAdd_invalidPastDateTime_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseVisitForAdd(INVALID_VISIT_DATETIME));
-    }
 
     @Test
     public void parseVisitForAdd_validValueWithoutWhitespace_returnsVisit() throws Exception {
@@ -293,11 +285,6 @@ public class ParserUtilTest {
     @Test
     public void parseLastVisit_invalidDateTime_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseLastVisit(INVALID_DATETIME));
-    }
-
-    @Test
-    public void parseLastVisit_invalidPastDateTime_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseLastVisit(INVALID_LAST_VISIT_DATETIME));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/LastVisitTest.java
+++ b/src/test/java/seedu/address/model/person/LastVisitTest.java
@@ -80,4 +80,16 @@ public class LastVisitTest {
         // format displayed date for empty visit
         assertEquals("-", new LastVisit("").getFormatted());
     }
+
+    @Test
+    public void isFuture() {
+        // no existing last visit
+        assertFalse(new LastVisit("").isFuture());
+
+        // overdue as of this module's time
+        assertTrue(new LastVisit("2077-01-01 08:00").isFuture());
+
+        // not overdue in around 100 years
+        assertFalse(new LastVisit("2000-01-01 08:00").isFuture());
+    }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,7 +26,7 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withLanguage("English")
-            .withPhone("94351253").withVisit("2021-10-10 12:00").withLastVisit("2021-07-07 12:00")
+            .withPhone("94351253").withVisit("2022-10-10 12:00").withLastVisit("2021-07-07 12:00")
             .withFrequency("").withOccurrence(1).withHealthConditions("diabetes").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")


### PR DESCRIPTION
Resolves #171 

## Implemented
- Warning message for invalid visit related fields
   - Implementation wise, such warnings are not checked during parsing, but during execution of the command. 
- Improved display for warning and errors
   - Warnings start with `[WARNING]` and the command result color is `#E38633`
   - Errors start with `[ERROR]` and the command result and command box color is `#D06651` 

### Warnings
There are two types of warning
1. When a visit date is in the past
    - This is applicable to `visit`, `add` and `edit` command
2. When a last visit date is in the future
    - This is applicable to `add` and `edit` command.

Note: Since both warnings can occur in `add` and `edit` commands. If such situations occur, they will be displayed as one line of warning instead of two separated ones. 